### PR TITLE
Improve k2s utilities

### DIFF
--- a/pyscf/lno/lnoccsd.py
+++ b/pyscf/lno/lnoccsd.py
@@ -544,17 +544,24 @@ def impurity_solve(mcc, mo_coeff, uocc_loc, mo_occ, maskact, eris,
             oovv = ovov.reshape(nactocc,nactvir,nactocc,nactvir).transpose(0,2,1,3)
             ovov = None
             cput1 = log.timer_debug1('imp sol - eri    ', *cput1)
+            
             # MP2 fragment energy
             t1, t2 = mcc.init_amps(eris=imp_eris)[1:]
             cput1 = log.timer_debug1('imp sol - mp2 amp', *cput1)
             elcorr_pt2 = get_fragment_energy(oovv, t2, uocc_loc).real
             cput1 = log.timer_debug1('imp sol - mp2 ene', *cput1)
+
             # CCSD fragment energy
             t1, t2 = mcc.kernel(eris=imp_eris, t1=t1, t2=t2)[1:]
+            if not mcc.converged:
+                log.warn('Impurity CCSD did not converge, please be careful of the results.')
+
             cput1 = log.timer_debug1('imp sol - cc  amp', *cput1)
             t2 += einsum('ia,jb->ijab',t1,t1)
             elcorr_cc = get_fragment_energy(oovv, t2, uocc_loc)
             cput1 = log.timer_debug1('imp sol - cc  ene', *cput1)
+            
+            # CCSD(T) fragment energy
             if ccsd_t:
                 if nactmo > max_las_size_ccsd_t:
                     log.warn('Number of active space orbitals (%d) exceed '

--- a/pyscf/lno/lnoccsd.py
+++ b/pyscf/lno/lnoccsd.py
@@ -671,6 +671,7 @@ class LNOCCSD(LNO):
         mcc._s1e = self._s1e
         mcc._h1e = self._h1e
         mcc._vhf = self._vhf
+
         if self.kwargs_imp is not None:
             mcc = mcc.set(**self.kwargs_imp)
 

--- a/pyscf/pbc/lno/klnoccsd.py
+++ b/pyscf/pbc/lno/klnoccsd.py
@@ -456,15 +456,9 @@ class KLNOCCSD(KLNO,LNOCCSD):
         self.verbose_imp = 2    # ERROR and WARNING
 
         # args for precompute
+        self._s1e = None
         self._h1e = None
         self._vhf = None
-
-    @property
-    def h1e(self):
-        if self._h1e is None:
-            kh1e = self._kscf.get_hcore()
-            self._h1e = k2s_aoint(self._kscf.cell, self.kpts, kh1e, name='h1e')
-        return self._h1e
 
     def impurity_solve(self, mf, mo_coeff, uocc_loc, eris, frozen=None, log=None):
         if log is None: log = logger.new_logger(self)
@@ -474,6 +468,7 @@ class KLNOCCSD(KLNO,LNOCCSD):
         mcc._s1e = self._s1e
         mcc._h1e = self._h1e
         mcc._vhf = self._vhf
+        
         if self.kwargs_imp is not None:
             mcc = mcc.set(**self.kwargs_imp)
 

--- a/pyscf/pbc/lno/klnoccsd.py
+++ b/pyscf/pbc/lno/klnoccsd.py
@@ -116,7 +116,7 @@ def K2SCCSD(mf, with_df, frozen, mo_coeff, mo_occ):
 class MODIFIED_K2SCCSD(MODIFIED_CCSD):
     def __init__(self, mf, with_df, frozen, mo_coeff, mo_occ):
         MODIFIED_CCSD.__init__(self, mf, frozen, mo_coeff, mo_occ)
-        self.k2sdf = K2SDF(with_df)
+        self._k2sdf = K2SDF(with_df)
 
     def ao2mo(self, mo_coeff=None):
         return _make_df_eris_outcore(self, mo_coeff)
@@ -135,7 +135,7 @@ def _make_df_eris_outcore(mycc, mo_coeff=None):
     nvir = nmo - nocc
     nvir_pair = nvir*(nvir+1)//2
 
-    k2sdf = mycc.k2sdf
+    k2sdf = mycc._k2sdf
     Naux = k2sdf.Naux_ibz
     naux = k2sdf.naux
     naux_by_q = k2sdf.naux_by_q
@@ -230,7 +230,7 @@ def _make_df_eris_outcore(mycc, mo_coeff=None):
 class MODIFIED_DFK2SCCSD(MODIFIED_DFCCSD):
     def __init__(self, mf, with_df, frozen, mo_coeff, mo_occ):
         MODIFIED_DFCCSD.__init__(self, mf, frozen, mo_coeff, mo_occ)
-        self.k2sdf = K2SDF(with_df)
+        self._k2sdf = K2SDF(with_df)
 
     def ao2mo(self, mo_coeff=None):
         return _make_df_eris(self, mo_coeff)
@@ -320,7 +320,7 @@ def _make_df_eris(mycc, mo_coeff=None):
     nvir_pair = nvir*(nvir+1)//2
     mo_coeff = eris.mo_coeff
 
-    k2sdf = mycc.k2sdf
+    k2sdf = mycc._k2sdf
     naux_by_q = k2sdf.naux_by_q
     naux = k2sdf.naux
     Naux = k2sdf.Naux_ibz

--- a/pyscf/pbc/lno/klnoccsd.py
+++ b/pyscf/pbc/lno/klnoccsd.py
@@ -114,9 +114,10 @@ def K2SCCSD(mf, with_df, frozen, mo_coeff, mo_occ):
             return MODIFIED_DFK2SCCSD_complex(mf, with_df, frozen, mo_coeff, mo_occ)
 
 class MODIFIED_K2SCCSD(MODIFIED_CCSD):
+    _keys = {"k2sdf"}
     def __init__(self, mf, with_df, frozen, mo_coeff, mo_occ):
         MODIFIED_CCSD.__init__(self, mf, frozen, mo_coeff, mo_occ)
-        self._k2sdf = K2SDF(with_df)
+        self.k2sdf = K2SDF(with_df)
 
     def ao2mo(self, mo_coeff=None):
         return _make_df_eris_outcore(self, mo_coeff)
@@ -135,7 +136,7 @@ def _make_df_eris_outcore(mycc, mo_coeff=None):
     nvir = nmo - nocc
     nvir_pair = nvir*(nvir+1)//2
 
-    k2sdf = mycc._k2sdf
+    k2sdf = mycc.k2sdf
     Naux = k2sdf.Naux_ibz
     naux = k2sdf.naux
     naux_by_q = k2sdf.naux_by_q
@@ -230,7 +231,7 @@ def _make_df_eris_outcore(mycc, mo_coeff=None):
 class MODIFIED_DFK2SCCSD(MODIFIED_DFCCSD):
     def __init__(self, mf, with_df, frozen, mo_coeff, mo_occ):
         MODIFIED_DFCCSD.__init__(self, mf, frozen, mo_coeff, mo_occ)
-        self._k2sdf = K2SDF(with_df)
+        self.k2sdf = K2SDF(with_df)
 
     def ao2mo(self, mo_coeff=None):
         return _make_df_eris(self, mo_coeff)
@@ -320,7 +321,7 @@ def _make_df_eris(mycc, mo_coeff=None):
     nvir_pair = nvir*(nvir+1)//2
     mo_coeff = eris.mo_coeff
 
-    k2sdf = mycc._k2sdf
+    k2sdf = mycc.k2sdf
     naux_by_q = k2sdf.naux_by_q
     naux = k2sdf.naux
     Naux = k2sdf.Naux_ibz

--- a/pyscf/pbc/lno/tools.py
+++ b/pyscf/pbc/lno/tools.py
@@ -28,11 +28,13 @@ def k2s_scf(kmf, fock_imag_tol=1e-6):
     kmo_coeff = kmf.mo_coeff
     kmo_energy = kmf.mo_energy
     ks1e = kmf.get_ovlp()
+    kh1e = kmf.get_hcore()
 
     ksc = [np.dot(s1e,mo_coeff) for s1e,mo_coeff in zip(ks1e,kmo_coeff)]
     kfock = np.asarray([np.dot(sc*moe,sc.T.conj()) for sc,moe in zip(ksc,kmo_energy)])
 
     s1e = _k2s_aoint(ks1e, kpts, phase, 's1e')
+    h1e = _k2s_aoint(kh1e, kpts, phase, 'h1e')
     fock = _k2s_aoint(kfock, kpts, phase, 'fock')
 
     mo_energy, mo_coeff = eig(fock, s1e)
@@ -44,6 +46,7 @@ def k2s_scf(kmf, fock_imag_tol=1e-6):
     mf.e_tot = kmf.e_tot * Nk
     mf.converged = True
     mf.get_ovlp = lambda *args: s1e
+    mf.get_hcore = lambda *args: h1e
 
     return mf
 

--- a/pyscf/pbc/lno/tools.py
+++ b/pyscf/pbc/lno/tools.py
@@ -431,9 +431,10 @@ def k2s_iao(cell, kocc_coeff, kpts, minao=MINAO, orth=False, s1e=None):
     iao_coeff = lib.einsum('Rk,kpq,Sk->RpSq', phase, kiao_coeff,
                            phase.conj()).reshape(nkpts*nao,nkpts*niao)
 
-    iao_coeff_imag = abs(iao_coeff.imag).max()
-    if gamma_point(kpts[0]) and iao_coeff_imag > 1e-10:
-        log.warn('Discard large imag part in k2s_iao: %6.2e.', iao_coeff_imag)
+    if gamma_point(kpts[0]):
+        iao_coeff_imag = abs(iao_coeff.imag).max()
+        if iao_coeff_imag > 1e-10:
+            log.warn('Discard large imag part in k2s_iao: %6.2e.', iao_coeff_imag)
         iao_coeff = iao_coeff.real
 
     return iao_coeff

--- a/pyscf/pbc/lno/tools.py
+++ b/pyscf/pbc/lno/tools.py
@@ -39,7 +39,7 @@ def k2s_scf(kmf, fock_imag_tol=1e-6):
 
     mo_energy, mo_coeff = eig(fock, s1e)
 
-    mf = scf.RHF(scell, kpt=kpts[0]).rs_density_fit(auxbasis=kmf.with_df.auxbasis)
+    mf = scf.RHF(scell, kpt=kpts[0])
     mf.mo_coeff = mo_coeff
     mf.mo_energy = mo_energy
     mf.mo_occ = mf.get_occ()


### PR DESCRIPTION
This PR improves the robustness of k-point to supercell utilities.

## Changes Made
- Add `k2sdf` to `_keys` in `MODIFIED_K2SCCSD` to resolve the warning:
  ```
  <class 'pyscf.pbc.lno.klnoccsd.MODIFIED_K2SCCSD'> does not have attributes k2sdf
  ```
- Update `k2s_scf` to properly include hcore from k-points calculation
- Removed `rs_density_fit` in `k2s_scf` for broader DF compatibility.
- Replace hard assertion with warning for large imaginary parts in IAO coefficients.

## Questions
- Will `get_vhf` be called under any condition? As `_precompute` will always pass `_vhf`.
- If this is true, RSDF for supercell will never be built.
